### PR TITLE
shutdown after invalid transport

### DIFF
--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -518,6 +518,13 @@ public class SipGatewaySession
         {
             logger.error(this.callContext + " " + error, error);
 
+            if (error instanceof IllegalArgumentException)
+            {
+                // e.g. "invalid transport" from SipStackSharing.getJainSipProvider
+                logger.warn(this.callContext + " ICC: Graceful Shutdown");
+                JigasiBundleActivator.enableGracefulShutdownMode(false);
+            }
+
             if (error instanceof OperationFailedException
                 && !CallManager.isHealthy())
             {
@@ -649,7 +656,7 @@ public class SipGatewaySession
                     callStateListener.handleCallState(sipCall, null);
                 }
             }
-            catch (OperationFailedException | ParseException e)
+            catch (IllegalArgumentException | OperationFailedException | ParseException e)
             {
                 return e;
             }


### PR DESCRIPTION
randomly happen... i had patched it in e8bc8ddae3d1d4d805ca04144989eeb5db281f25 but this is the call init.

```
2023-07-28 18:53:55.634 INFO: [481053] net.java.sip.communicator.impl.protocol.sip.OperationSetBasicTelephonySipImpl.createOutgoingCall: Creating outgoing call to sip:27333224_301131@telephony.com
2023-07-28 18:53:55.634 SEVERE: [481053] net.java.sip.communicator.util.UtilActivator.uncaughtException: An uncaught exception occurred in thread=Thread[Thread-416651,5,main], and message was: invalid transport
java.lang.IllegalArgumentException: invalid transport
    at net.java.sip.communicator.impl.protocol.sip.SipStackSharing.getJainSipProvider(SipStackSharing.java:511)
    at net.java.sip.communicator.impl.protocol.sip.ProtocolProviderServiceSipImpl.getJainSipProvider(ProtocolProviderServiceSipImpl.java:1699)
    at net.java.sip.communicator.impl.protocol.sip.ProtocolProviderServiceSipImpl.getDefaultJainSipProvider(ProtocolProviderServiceSipImpl.java:2078)
    at net.java.sip.communicator.impl.protocol.sip.SipMessageFactory.createInviteRequest(SipMessageFactory.java:736)
    at net.java.sip.communicator.impl.protocol.sip.SipMessageFactory.createInviteRequest(SipMessageFactory.java:876)
    at net.java.sip.communicator.impl.protocol.sip.CallSipImpl.invite(CallSipImpl.java:468)
    at net.java.sip.communicator.impl.protocol.sip.OperationSetBasicTelephonySipImpl.createOutgoingCall(OperationSetBasicTelephonySipImpl.java:197)
    at net.java.sip.communicator.impl.protocol.sip.OperationSetBasicTelephonySipImpl.createCall(OperationSetBasicTelephonySipImpl.java:139)
    at net.java.sip.communicator.service.protocol.media.AbstractOperationSetBasicTelephony.createCall(AbstractOperationSetBasicTelephony.java:121)
    at org.jitsi.jigasi.SipGatewaySession.onConferenceCallStarted(SipGatewaySession.java:636)
    at org.jitsi.jigasi.SipGatewaySession.onConferenceCallInvited(SipGatewaySession.java:515)
    at org.jitsi.jigasi.JvbConference$JvbCallListener.incomingCallReceived(JvbConference.java:1413)
    at net.java.sip.communicator.service.protocol.media.AbstractOperationSetBasicTelephony.fireCallEvent(AbstractOperationSetBasicTelephony.java:206)
    at net.java.sip.communicator.service.protocol.media.AbstractOperationSetBasicTelephony.fireCallEvent(AbstractOperationSetBasicTelephony.java:165)
    at net.java.sip.communicator.impl.protocol.jabber.CallJabberImpl.processSessionInitiate(CallJabberImpl.java:422)
    at net.java.sip.communicator.impl.protocol.jabber.OperationSetBasicTelephonyJabberImpl.lambda$processJingleIQ$0(OperationSetBasicTelephonyJabberImpl.java:1095)
    at java.base/java.lang.Thread.run(Thread.java:829)
2023-07-28 18:56:22.408 INFO: [481080] net.java.sip.communicator.impl.protocol.jabber.ChatRoomJabberImpl$MemberListener.joined: id-27333224@conference.tv-amer-1.freeconference.com/47237757 has joined the id-27333224@conference.tv-amer-1.freeconference.com chat room.
```